### PR TITLE
fix file phoenix-2.0.0/src/Makefile to make directory before copy

### DIFF
--- a/phoenix-2.0.0/phoenix-2.0.0/src/Makefile
+++ b/phoenix-2.0.0/phoenix-2.0.0/src/Makefile
@@ -57,6 +57,7 @@ default: all
 all: $(HOME)/$(LIB_DIR)/$(TARGET)
 
 $(HOME)/$(LIB_DIR)/$(TARGET): $(TARGET)
+	test -d $(HOME)/$(LIB_DIR) || mkdir $(HOME)/$(LIB_DIR)
 	cp $< $(HOME)/$(LIB_DIR)
 
 $(LIB_PHOENIX).a: $(OBJS)


### PR DESCRIPTION
phoenix-2.0.0/src/Makefile bug.
cp $< $(HOME)/$(LIB_DIR)
is not working correctly.